### PR TITLE
Fix dialog stack

### DIFF
--- a/src/mvc/ModalView.js
+++ b/src/mvc/ModalView.js
@@ -324,7 +324,7 @@ var ModalView = function (message, params) {
     // Mask already has a dialog in it, add to dialog stack and continue
     while (_MASK.firstChild) {
       oldChild = _MASK.firstChild;
-      if (oldChild.modal instanceof ModalView) {
+      if (oldChild.modal) {
         _DIALOG_STACK.push(oldChild.modal);
       }
       _MASK.removeChild(oldChild);


### PR DESCRIPTION
This fixes the issue where the eventpage dyfi form closes after location is selected (because the form is not pushed onto the dialog stack when the location view is shown)