### PR TITLE
Allow _selected to be null

### DIFF
--- a/src/mvc/Collection.js
+++ b/src/mvc/Collection.js
@@ -223,7 +223,7 @@ var Collection = function (data) {
       _this.deselect();
     }
 
-    if (obj === _this.get(obj.id)) {
+    if (obj === null || obj === _this.get(obj.id)) {
       // make sure it's part of this collection…
       _selected = obj;
       _this.trigger('select', _selected, options);


### PR DESCRIPTION
This allows the blank option to be selected in the CollectionSelectBox