### PR TITLE
Remove "destroy" call from Collection.reset(), create tests

### DIFF
--- a/src/mvc/Collection.js
+++ b/src/mvc/Collection.js
@@ -193,7 +193,8 @@ var Collection = function (data) {
     }
 
     // free array and id cache
-    _this.destroy();
+    _data = null;
+    _ids = null;
 
     // set new array
     _data = data || [];
@@ -201,11 +202,15 @@ var Collection = function (data) {
     // notify listeners
     _this.trigger('reset', data);
 
-    // reselect if there was a previous selection
-    if (selectedId !== null) {
+    // reselect if there was a previous selection, otherwise deselect (silently)
+    if (selectedId === null) {
+      _selected = null;
+    } else {
       var selected = _this.get(selectedId);
       if (selected !== null) {
         _this.select(selected, {'reset':true});
+      } else {
+        _selected = null;
       }
     }
   };

--- a/test/spec/mvc/CollectionTest.js
+++ b/test/spec/mvc/CollectionTest.js
@@ -125,6 +125,64 @@ describe('Unit tests for the "Collection" class', function () {
   });
 
 
+  describe('reset()', function () {
+    it('triggers "reset" event when the collection is reset', function () {
+      var collection = Collection(),
+          listener = new TestClass();
+
+      collection.on('reset', listener.callback, listener);
+      collection.reset([]);
+
+      expect(listener.callbackCount).to.equal(1);
+      expect(listener.callbackData).to.deep.equal([]);
+    });
+
+    it('does not throws exception when no parameters are passed', function () {
+      var model = Model({'id': 'test'}),
+          model2 = Model({'id': 'test2'}),
+          collection = Collection();
+
+      collection.add(model, model2);
+
+      expect(function () {
+        collection.reset();
+      }).to.not.throw(Error);
+    });
+
+    it('maintains selection when item IS in reset collection', function () {
+      var model = Model({'id': 'test'}),
+          model2 = Model({'id': 'test2'}),
+          model3 = Model({'id': 'test3'}),
+          collection = Collection();
+
+      collection.add(model, model2, model3);
+      collection.select(model2);
+      expect(collection.data().length).to.equal(3);
+      expect(collection.get('test2')).to.deep.equal(model2);
+
+      collection.reset([model2, model3]);
+      expect(collection.data().length).to.equal(2);
+      expect(collection.get('test2')).to.deep.equal(model2);
+    });
+
+    it('clears selection when item IS NOT in reset collection', function () {
+      var model = Model({'id': 'test'}),
+          model2 = Model({'id': 'test2'}),
+          model3 = Model({'id': 'test3'}),
+          collection = Collection();
+
+      collection.add(model, model2, model3);
+      collection.select(model2);
+      expect(collection.data().length).to.equal(3);
+      expect(collection.get('test2')).to.deep.equal(model2);
+
+      collection.reset([model, model3]);
+      expect(collection.data().length).to.equal(2);
+      expect(collection.get('test2')).to.deep.equal(null);
+    });
+  });
+
+
   describe('select()', function () {
     it('triggers "select" event when called', function () {
       var model = Model({'id': 'test'}),


### PR DESCRIPTION
This is a simple change that we talked about that could be an alternative to the changes Jeremy is making. I just wanted to put this PR in with the other option so that we can compare the two different options on Monday. 