### PR TITLE
Usgs/hazdev webutils#70

### DIFF
--- a/example/CollectionSelectBoxUITest.js
+++ b/example/CollectionSelectBoxUITest.js
@@ -2,21 +2,38 @@
 'use strict';
 
 var Collection = require('mvc/Collection'),
-    Model = require('mvc/Model'),
-    CollectionSelectBox = require('mvc/CollectionSelectBox');
+    CollectionSelectBox = require('mvc/CollectionSelectBox'),
+    Model = require('mvc/Model');
 
 
-var c = Collection(),
-    box1 = document.querySelector('#selectBox1'),
-    box2 = document.querySelector('#selectBox2'),
-    modelId = 0;
+var box1,
+    box2,
+    c,
+    modelId;
 
-CollectionSelectBox({collection: c, el: box1});
-CollectionSelectBox({collection: c, el: box2});
+c = Collection();
+box1 = document.querySelector('#selectBox1');
+box2 = document.querySelector('#selectBox2');
+modelId = 0;
+
+
+CollectionSelectBox({
+  collection: c,
+  el: box1
+});
+CollectionSelectBox({
+  collection: c,
+  el: box2
+});
 
 var addModel = function () {
-  var m = Model({id: modelId, value: '' + modelId,
-      display: 'Custom Model ' + modelId});
+  var m;
+
+  m = Model({
+        display: 'Custom Model ' + modelId,
+        id: modelId,
+        value: '' + modelId
+      });
 
   c.add(m);
 
@@ -24,7 +41,10 @@ var addModel = function () {
 };
 
 var removeModel = function () {
-  var data = c.data();
+  var data;
+
+  data = c.data();
+
   if (!data || data.length <= 0) {
     alert('No more items to remove!');
     return;
@@ -48,3 +68,68 @@ addModel();
 addModel();
 addModel();
 addModel();
+
+
+
+var box3,
+    c2,
+    m2,
+    output,
+    select;
+
+box3 = document.querySelector('#selectBox3');
+output = document.querySelector('#output');
+c2 = Collection();
+
+m2 = Model({
+  error: null,
+  id: 'ID-101',
+  value: 'show me'
+});
+
+c2.add({
+  error: 'Yes, 20',
+  id: 'Error',
+  value: 'one-oh-three'
+});
+c2.add({
+  error: null,
+  id: 'No-error',
+  value: 'No error'
+});
+
+select = CollectionSelectBox({
+  collection: c2,
+  el: box3,
+  includeBlankOption: true,
+  model: m2
+});
+
+var updateModel = function () {
+  var selected;
+
+  selected = c2.getSelected();
+
+  m2.set({
+    error: selected.error,
+    id: selected.id,
+    value: selected.value
+  });
+};
+
+var updateOutput = function () {
+  var text;
+
+  text = [
+    '{' +
+      'error: ' + select.model.get('error') + ', ' +
+      'id: ' + select.model.id + ', ' +
+      'value: ' + select.model.get('value') +
+    '}'
+  ].join();
+
+  output.innerHTML = text;
+};
+
+c2.on('select', updateModel);
+box3.addEventListener('click', updateOutput);

--- a/example/CollectionSelectBoxUITest.js
+++ b/example/CollectionSelectBoxUITest.js
@@ -84,6 +84,7 @@ c2 = Collection();
 m2 = Model({
   error: null,
   id: 'ID-101',
+  stuff: 'yeah, more stuff',
   value: 'show me'
 });
 

--- a/example/CollectionSelectBoxUITest.js
+++ b/example/CollectionSelectBoxUITest.js
@@ -132,5 +132,7 @@ var updateOutput = function () {
   output.innerHTML = text;
 };
 
+// Make sure to bind to both select and deselect for full functionality.
+c2.on('deselect', updateModel);
 c2.on('select', updateModel);
 box3.addEventListener('click', updateOutput);

--- a/example/CollectionSelectBoxUITest.js
+++ b/example/CollectionSelectBoxUITest.js
@@ -107,23 +107,43 @@ select = CollectionSelectBox({
 });
 
 var updateModel = function () {
-  var selected;
+  var error,
+      id,
+      selected,
+      value;
 
   selected = c2.getSelected();
 
+  try {
+    error = selected.error;
+    id = selected.id;
+    value = selected.value;
+  } catch (e) {
+    error = 'null';
+    id = 'null';
+    value = 'null';
+  }
+
   m2.set({
-    error: selected.error,
-    id: selected.id,
-    value: selected.value
+    error: error,
+    id: id,
+    value: value
   });
 };
 
 var updateOutput = function () {
-  var text;
+  var error,
+      text;
+
+  try {
+    error = select.model.get('error');
+  } catch (e) {
+    error = 'null';
+  }
 
   text = [
     '{' +
-      'error: ' + select.model.get('error') + ', ' +
+      'error: ' + error + ', ' +
       'id: ' + select.model.id + ', ' +
       'value: ' + select.model.get('value') +
     '}'

--- a/example/CollectionSelectBoxUITest.php
+++ b/example/CollectionSelectBoxUITest.php
@@ -1,5 +1,4 @@
 <?php
-
 if (!isset($TEMPLATE)) {
   $TITLE = 'Collection SelectBox Example';
   $NAVIGATION = true;
@@ -14,10 +13,11 @@ if (!isset($TEMPLATE)) {
 }
 
 include '_example.inc.php';
-
 ?>
 
-  <p class="instructions">
+<section>
+  <h2>Same Collection</h2>
+  <p>
     Below are two select views that are bound to the same collection. By
     selecting an item in either select box, the select items in both box select
     boxes should update.
@@ -25,7 +25,7 @@ include '_example.inc.php';
   <select id="selectBox1"></select>
   <select id="selectBox2"></select>
 
-  <p class="instructions">
+  <p>
     Use the buttons below to add, remove, or clear items to/from the underlying
     collection. You should see the results of your action reflected in both
     select boxes above.
@@ -34,4 +34,15 @@ include '_example.inc.php';
   <button id="addItem">Add New Item</button>
   <button id="removeItem">Remove First Item</button>
   <button id="resetItems">Clear All Items</button>
+</section>
 
+<hr />
+
+<section>
+  <h2>Include Blank Option</h2>
+  <p>
+    This select box uses the *includeBlankOption* key.
+  </p>
+
+  <select id="selectBox3"></select>
+</section>

--- a/example/CollectionSelectBoxUITest.php
+++ b/example/CollectionSelectBoxUITest.php
@@ -45,4 +45,8 @@ include '_example.inc.php';
   </p>
 
   <select id="selectBox3"></select>
+  <p>
+    The selected model looks like this:
+    <span id="output"></span>
+  </p>
 </section>

--- a/example/CollectionSelectBoxUITest.php
+++ b/example/CollectionSelectBoxUITest.php
@@ -47,6 +47,6 @@ include '_example.inc.php';
   <select id="selectBox3"></select>
   <p>
     The selected model looks like this:
-    <span id="output"></span>
   </p>
+  <span id="output"></span>
 </section>

--- a/src/mvc/CollectionSelectBox.js
+++ b/src/mvc/CollectionSelectBox.js
@@ -9,7 +9,7 @@ var _DEFAULTS = {
   className: 'collection-selectbox',
   includeBlankOption: false,
   blankOption: {
-    id: 'Please select...',
+    text: 'Please select&hellip;',
     value: '-1'
   },
 
@@ -49,6 +49,7 @@ var CollectionSelectBox = function (params) {
       _includeBlankOption,
       _selectBox,
 
+      _createBlankOption,
       _defaultGetValidOptions,
       _onChange,
       _onSelect;
@@ -72,9 +73,6 @@ var CollectionSelectBox = function (params) {
     _getValidOptions = params.getValidOptions || _defaultGetValidOptions;
     _includeBlankOption = params.includeBlankOption;
 
-    if (_includeBlankOption) {
-      _collection.add(_blankOption);
-    }
     // reuse or create select box
     if (el.nodeName === 'SELECT') {
       _selectBox = el;
@@ -97,6 +95,15 @@ var CollectionSelectBox = function (params) {
     if (params.renderNow) {
       _this.render();
     }
+  };
+
+  _createBlankOption = function () {
+    return [
+    '<option ',
+        'value="', _blankOption.value, '">',
+      _blankOption.text,
+    '</option>'
+    ].join('');
   };
 
   _defaultGetValidOptions = function () {
@@ -135,7 +142,7 @@ var CollectionSelectBox = function (params) {
         _selectBox.value = selected.id;
       }
     } else if (_includeBlankOption) {
-      _collection.selectById(_blankOption.value);
+      _selectBox.value = _blankOption.value;
     }
   };
 
@@ -159,6 +166,7 @@ var CollectionSelectBox = function (params) {
     _includeBlankOption = null;
     _selectBox = null;
 
+    _createBlankOption = null;
     _defaultGetValidOptions = null;
     _onChange = null;
     _onSelect = null;
@@ -183,12 +191,8 @@ var CollectionSelectBox = function (params) {
     markup = [];
     selected = _collection.getSelected();
 
-    if (_includeBlankOption && selected === null) {
-      data.map(function (d) {
-        if (d.id === _blankOption.id) {
-          _collection.select(d);
-        }
-      });
+    if (_includeBlankOption === true) {
+      markup.push(_createBlankOption());
     }
 
     validOptions = _getValidOptions();

--- a/src/mvc/CollectionSelectBox.js
+++ b/src/mvc/CollectionSelectBox.js
@@ -9,8 +9,8 @@ var _DEFAULTS = {
   className: 'collection-selectbox',
   includeBlankOption: false,
   blankOption: {
-    value: '-1',
-    text: 'Please select&hellip;'
+    id: 'Please select...',
+    value: '-1'
   },
 
   // callback to format each collection item
@@ -49,7 +49,6 @@ var CollectionSelectBox = function (params) {
       _includeBlankOption,
       _selectBox,
 
-      _createBlankOption,
       _defaultGetValidOptions,
       _onChange,
       _onSelect;
@@ -73,6 +72,9 @@ var CollectionSelectBox = function (params) {
     _getValidOptions = params.getValidOptions || _defaultGetValidOptions;
     _includeBlankOption = params.includeBlankOption;
 
+    if (_includeBlankOption) {
+      _collection.add(_blankOption);
+    }
     // reuse or create select box
     if (el.nodeName === 'SELECT') {
       _selectBox = el;
@@ -95,15 +97,6 @@ var CollectionSelectBox = function (params) {
     if (params.renderNow) {
       _this.render();
     }
-  };
-
-  _createBlankOption = function () {
-    return [
-    '<option ',
-        'value="', _blankOption.value, '">',
-      _blankOption.text,
-    '</option>'
-    ].join('');
   };
 
   _defaultGetValidOptions = function () {
@@ -142,7 +135,8 @@ var CollectionSelectBox = function (params) {
         _selectBox.value = selected.id;
       }
     } else if (_includeBlankOption) {
-      _selectBox.value = _blankOption.value;
+      // _selectBox.value = _blankOption.value;
+      _collection.selectById(_blankOption.value);
     }
   };
 
@@ -166,7 +160,6 @@ var CollectionSelectBox = function (params) {
     _includeBlankOption = null;
     _selectBox = null;
 
-    _createBlankOption = null;
     _defaultGetValidOptions = null;
     _onChange = null;
     _onSelect = null;
@@ -191,8 +184,12 @@ var CollectionSelectBox = function (params) {
     markup = [];
     selected = _collection.getSelected();
 
-    if (_includeBlankOption === true) {
-      markup.push(_createBlankOption());
+    if (_includeBlankOption && selected === null) {
+      data.map(function (d) {
+        if (d.id === _blankOption.id) {
+          _collection.select(d);
+        }
+      });
     }
 
     validOptions = _getValidOptions();

--- a/src/mvc/CollectionSelectBox.js
+++ b/src/mvc/CollectionSelectBox.js
@@ -63,7 +63,9 @@ var CollectionSelectBox = function (params) {
    *
    */
   _initialize = function (params) {
-    var el = _this.el;
+    var el;
+
+    el = _this.el;
 
     _blankOption = params.blankOption;
     _collection = params.collection;
@@ -93,8 +95,6 @@ var CollectionSelectBox = function (params) {
     if (params.renderNow) {
       _this.render();
     }
-
-    params = null;
   };
 
   _createBlankOption = function () {
@@ -114,7 +114,9 @@ var CollectionSelectBox = function (params) {
    * Handle selectbox change events.
    */
   _onChange = function () {
-    var value = _selectBox.value;
+    var value;
+
+    value = _selectBox.value;
 
     if (_includeBlankOption && value === _blankOption.value) {
       _collection.deselect();
@@ -186,8 +188,8 @@ var CollectionSelectBox = function (params) {
         validOptions;
 
     data = _collection.data();
-    selected = _collection.getSelected();
     markup = [];
+    selected = _collection.getSelected();
 
     if (_includeBlankOption === true) {
       markup.push(_createBlankOption());

--- a/src/mvc/CollectionSelectBox.js
+++ b/src/mvc/CollectionSelectBox.js
@@ -62,14 +62,14 @@ var CollectionSelectBox = function (params) {
    * @constructor
    *
    */
-  _initialize = function () {
+  _initialize = function (params) {
     var el = _this.el;
 
-    _collection = params.collection;
     _blankOption = params.blankOption;
-    _includeBlankOption = params.includeBlankOption;
+    _collection = params.collection;
     _format = params.format;
     _getValidOptions = params.getValidOptions || _defaultGetValidOptions;
+    _includeBlankOption = params.includeBlankOption;
 
     // reuse or create select box
     if (el.nodeName === 'SELECT') {
@@ -97,6 +97,14 @@ var CollectionSelectBox = function (params) {
     params = null;
   };
 
+  _createBlankOption = function () {
+    return [
+    '<option ',
+        'value="', _blankOption.value, '">',
+      _blankOption.text,
+    '</option>'
+    ].join('');
+  };
 
   _defaultGetValidOptions = function () {
     return _collection.data().map(function (o) { return o.id; });
@@ -136,14 +144,6 @@ var CollectionSelectBox = function (params) {
     }
   };
 
-  _createBlankOption = function () {
-    return [
-    '<option ',
-        'value="', _blankOption.value, '">',
-      _blankOption.text,
-    '</option>'
-    ].join('');
-  };
 
   /**
    * Destroy CollectionSelectBox.
@@ -157,20 +157,17 @@ var CollectionSelectBox = function (params) {
 
     _selectBox.removeEventListener('change', _onChange);
 
-
     _blankOption = null;
     _collection = null;
-    _includeBlankOption = null;
     _format = null;
     _getValidOptions = null;
+    _includeBlankOption = null;
     _selectBox = null;
-
 
     _createBlankOption = null;
     _defaultGetValidOptions = null;
     _onChange = null;
     _onSelect = null;
-
 
     _initialize = null;
     _this = null;
@@ -181,11 +178,11 @@ var CollectionSelectBox = function (params) {
    */
   _this.render = function () {
     var data,
-        selected,
         i,
         id,
         len,
         markup,
+        selected,
         validOptions;
 
     data = _collection.data();
@@ -212,7 +209,8 @@ var CollectionSelectBox = function (params) {
   };
 
 
-  _initialize();
+  _initialize(params);
+  params = null;
   return _this;
 };
 

--- a/src/mvc/CollectionSelectBox.js
+++ b/src/mvc/CollectionSelectBox.js
@@ -135,7 +135,6 @@ var CollectionSelectBox = function (params) {
         _selectBox.value = selected.id;
       }
     } else if (_includeBlankOption) {
-      // _selectBox.value = _blankOption.value;
       _collection.selectById(_blankOption.value);
     }
   };

--- a/test/spec/mvc/CollectionSelectBoxTest.js
+++ b/test/spec/mvc/CollectionSelectBoxTest.js
@@ -115,10 +115,9 @@ describe('Unit tests for the "CollectionSelectBox" class', function () {
         includeBlankOption: true
       });
 
-      // collection.deselect();
+      collection.deselect();
 
-      // expect(el.value).to.equal('-1');
-      expect(el.value).to.equal('2');
+      expect(el.value).to.equal('-1');
     });
   });
 });

--- a/test/spec/mvc/CollectionSelectBoxTest.js
+++ b/test/spec/mvc/CollectionSelectBoxTest.js
@@ -115,9 +115,10 @@ describe('Unit tests for the "CollectionSelectBox" class', function () {
         includeBlankOption: true
       });
 
-      collection.deselect();
+      // collection.deselect();
 
-      expect(el.value).to.equal('-1');
+      // expect(el.value).to.equal('-1');
+      expect(el.value).to.equal('2');
     });
   });
 });


### PR DESCRIPTION
Fixes #70 
Fixes usgs/hazdev-webutils#70

The `blankOption` is now part of the collection when it is included.

It also puts the blank option at the bottom of the list instead of the top. I think that is where it belongs since it is not the option we want the user to select, but we can change that if needed.