### PR TITLE
Preserve eigenvalues

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ will be fixed in a subsequent update.
 
 Changelog
 ---------
+### 0.1.7 - 2016-01-07
+ - Added DataTable `column` parameter `downloadTitle` for custom download
+   formatting.
 
 ### 0.0.5 - 2014-02-24
  - Added toJSON method to Collection and Model for serialization to JSON.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hazdev-webutils",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "http://earthquake.usgs.gov/",
   "repository": "https://github.com/usgs/hazdev-webutils.git",
   "description": "Utilities commonly used in web applications developed by the EHP HazDev team.",

--- a/src/math/Matrix.js
+++ b/src/math/Matrix.js
@@ -255,8 +255,7 @@ __jacobi = function (data, m, n, maxRotations) {
   for (i = 0; i < n; i++) {
     // i-th vector is i-th column
     vector = Vector(__col(v, m, n, i));
-    // set vector magnitude to value
-    vector = vector.multiply(e[i]);
+    vector.eigenvalue = e[i];
     vectors.push(vector);
   }
 

--- a/test/spec/math/MatrixTest.js
+++ b/test/spec/math/MatrixTest.js
@@ -53,20 +53,20 @@ describe('Unit tests for the "Matrix" class', function () {
       ], 3, 3);
       ev = m.jacobi();
 
-      expect(ev[0].magnitude()).to.be.closeTo(1.3080, 1e-4);
-      expect(ev[0].unit().x()).to.be.closeTo(0.7370, 1e-4);
-      expect(ev[0].unit().y()).to.be.closeTo(-0.5910, 1e-4);
-      expect(ev[0].unit().z()).to.be.closeTo(-0.3280, 1e-4);
+      expect(ev[0].eigenvalue).to.be.closeTo(1.3080, 1e-4);
+      expect(ev[0].x()).to.be.closeTo(0.7370, 1e-4);
+      expect(ev[0].y()).to.be.closeTo(-0.5910, 1e-4);
+      expect(ev[0].z()).to.be.closeTo(-0.3280, 1e-4);
 
-      expect(ev[1].magnitude()).to.be.closeTo(1.6431, 1e-4);
-      expect(ev[1].unit().x()).to.be.closeTo(0.3280, 1e-4);
-      expect(ev[1].unit().y()).to.be.closeTo(0.7370, 1e-4);
-      expect(ev[1].unit().z()).to.be.closeTo(-0.5910, 1e-4);
+      expect(ev[1].eigenvalue).to.be.closeTo(1.6431, 1e-4);
+      expect(ev[1].x()).to.be.closeTo(0.3280, 1e-4);
+      expect(ev[1].y()).to.be.closeTo(0.7370, 1e-4);
+      expect(ev[1].z()).to.be.closeTo(-0.5910, 1e-4);
 
-      expect(ev[2].magnitude()).to.be.closeTo(6.0489, 1e-4);
-      expect(ev[2].unit().x()).to.be.closeTo(0.5910, 1e-4);
-      expect(ev[2].unit().y()).to.be.closeTo(0.3280, 1e-4);
-      expect(ev[2].unit().z()).to.be.closeTo(0.7370, 1e-4);
+      expect(ev[2].eigenvalue).to.be.closeTo(6.0489, 1e-4);
+      expect(ev[2].x()).to.be.closeTo(0.5910, 1e-4);
+      expect(ev[2].y()).to.be.closeTo(0.3280, 1e-4);
+      expect(ev[2].z()).to.be.closeTo(0.7370, 1e-4);
     });
   });
 


### PR DESCRIPTION
Sometimes eigenvalues are negative, which is useful information that is lost when only setting vector magnitude.